### PR TITLE
pre-create output array for generate()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE Stuff
+.idea/*

--- a/pygsm/pygsm2016.py
+++ b/pygsm/pygsm2016.py
@@ -116,7 +116,7 @@ class GlobalSkyModel2016(object):
         nfreq = spec_nf.shape[1]
 
         output = np.zeros((len(freqs_ghz), map_ni.shape[1]), dtype='float32')
-        for freq in freqs_ghz:
+        for ifreq, freq in enumerate(freqs_ghz):
 
             left_index = -1
             for i in range(nfreq - 1):
@@ -133,9 +133,9 @@ class GlobalSkyModel2016(object):
             y2 = interp_spec_nf[1:, left_index + 1]
             x = np.log10(freq)
             interpolated_vals = (x * (y2 - y1) + x2 * y1 - x1 * y2) / (x2 - x1)
-            output[i] = np.sum(10.**interpolated_vals[0] * (interpolated_vals[1:, None] * map_ni), axis=0)
+            output[ifreq] = np.sum(10.**interpolated_vals[0] * (interpolated_vals[1:, None] * map_ni), axis=0)
 
-            output[i] = hp.pixelfunc.reorder(output[i], n2r=True)
+            output[ifreq] = hp.pixelfunc.reorder(output[ifreq], n2r=True)
 
             if self.unit == 'TCMB':
                 conversion = 1. / K_CMB2MJysr(1., 1e9 * freq)
@@ -143,7 +143,7 @@ class GlobalSkyModel2016(object):
                 conversion = 1. / K_RJ2MJysr(1., 1e9 * freq)
             else:
                 conversion = 1.
-            output[i] *= conversion
+            output[ifreq] *= conversion
 
 #            output.append(result)
 


### PR DESCRIPTION
Hi there,

I was getting MemoryError when running with ~100 frequencies. It seemed like the error was coming after all the interpolation was done, when trying to stack the lists into an array. 

This pull request fixes this (I think) by instantiating the array up-front, and filling it within the loop. 

I did a bit of memory profiling and got the following time-based plots. Here is the code that I ran:

`from pygsm import GlobalSkyModel2016
import numpy as np
import time

gsm = GlobalSkyModel2016()

time.sleep(2)

nu =np.linspace(150,160,20)

gsm.generate(nu)
`

So I'm running with 20 frequencies. For the old code I get this:

![old_memory_prof](https://user-images.githubusercontent.com/1272030/29118739-cb11952e-7d35-11e7-93dd-13930172dce6.png)

With the new code I get this:

![new_memory_prof](https://user-images.githubusercontent.com/1272030/29118784-090aaf28-7d36-11e7-822e-507675aee441.png)

Let me know if anything seems off.

Cheers,
Steven

